### PR TITLE
Refactor SignedObject API around CONTENT-TYPE instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 A library and associated command line utility for quickly creating and reading
 arbitrary RPKI signed objects.
 
-The primary motivation was to be able to construct new object types directly
-from the ASN.1 `EncapsulatedContentInfo` definition with minimal boilerplate
-and zero custom encoding logic.
+The primary motivation was to be able to construct new RPKI signed object types
+directly from an ASN.1 `CONTENT-TYPE` instance definition with minimal
+boilerplate and zero custom encoding logic.
 
 The base distribution comes with the necessary plumbing to read and write the
 currently standardised object types:
@@ -28,9 +28,9 @@ currently standardised object types:
 - ROAs (RFC6482)
 - Ghostbuster Records (RFC6493)
 
-Additional signed objects can be supported via a plugin system.
+Additional signed objects can be supported via a plug-in system.
 
-This **not** an RP or a CA.
+This is **not** an RP or a CA.
 
 Minimal validation is done on object creation. This is intentional, since a
 valid use-case is to create *almost* valid objects to recreate RP bugs.
@@ -68,9 +68,9 @@ The `rpkincant` CLI tool ships with two subcommands:
     The result is written to STDOUT by default, in a variety of selectable
     formats.
 
-## Writing Plugins
+## Writing Plug-ins
 
-Plugins implementing new signed object types can advertise the required
+Plug-ins implementing new signed object types can advertise the required
 components to `rpkimancer` using the following entry points:
 
 -   `rpkimancer.asn1.modules`:
@@ -113,7 +113,7 @@ Both feature contributions and bug fixes are very welcome.
 Please open an issue for discussion before expending energy on an implementation.
 
 Pre-standard RPKI object implementations will not be accepted into the main library.
-These should be implemented in a standalone plugin distribution while still in the
+These should be implemented in a standalone plug-in distribution while still in the
 I-D phase.
 
 To set up a development environment:

--- a/rpkimancer/algorithms.py
+++ b/rpkimancer/algorithms.py
@@ -20,9 +20,8 @@ import typing
 log = logging.getLogger(__name__)
 
 
-AlgorithmDict = typing.Dict[typing.Tuple[int, ...],
-                            typing.Callable[[bytes],
-                                            "hashlib._Hash"]]
+DigestAlgorithm = typing.Callable[[bytes], "hashlib._Hash"]
+AlgorithmDict = typing.Dict[typing.Tuple[int, ...], DigestAlgorithm]
 
 SHA256: typing.Final = (2, 16, 840, 1, 101, 3, 4, 2, 1)
 

--- a/rpkimancer/asn1/__init__.py
+++ b/rpkimancer/asn1/__init__.py
@@ -26,8 +26,8 @@ log = logging.getLogger(__name__)
 
 log_writer = LogWriter(log, level=logging.WARNING)
 
-ContentSubclass = typing.TypeVar("ContentSubclass",
-                                 bound="Content")
+InterfaceSubclass = typing.TypeVar("InterfaceSubclass",
+                                   bound="Interface")
 
 
 def append_info_object_set(obj_set: ASN1Class, *obj_ins: ASN1Class) -> None:
@@ -39,7 +39,7 @@ def append_info_object_set(obj_set: ASN1Class, *obj_ins: ASN1Class) -> None:
     pycrate_asn1rt.init.build_classset_dict(obj_set)
 
 
-class Content:
+class Interface:
     """Generic base ASN.1 type wrapping pycrates API."""
 
     content_syntax: ASN1Obj
@@ -59,16 +59,16 @@ class Content:
         log.info(f"finished initialisation of {self} ASN.1 content")
 
     @classmethod
-    def from_data(cls, data: typing.Any) -> ContentSubclass:
+    def from_data(cls, data: typing.Any) -> InterfaceSubclass:
         """Construct an instance from python data."""
         log.info(f"creating new {cls} object")
-        self: ContentSubclass = cls.__new__(cls)
-        Content.__init__(self, data)
+        self: InterfaceSubclass = cls.__new__(cls)
+        Interface.__init__(self, data)
         return self
 
     @classmethod
-    def from_der(cls: typing.Type[ContentSubclass],
-                 der_data: bytes) -> ContentSubclass:
+    def from_der(cls: typing.Type[InterfaceSubclass],
+                 der_data: bytes) -> InterfaceSubclass:
         """Construct an instance from DER encoded data."""
         log.info(f"trying to acquire lock for {cls}")
         with cls._lock:
@@ -78,8 +78,8 @@ class Content:
             data = cls.content_syntax.get_val()
             cls.content_syntax.reset_val()
             log.info(f"finished deserialising {cls} object")
-        self: ContentSubclass = cls.__new__(cls)
-        Content.__init__(self, data)
+        self: InterfaceSubclass = cls.__new__(cls)
+        Interface.__init__(self, data)
         return self
 
     @property

--- a/rpkimancer/cert/asn1.py
+++ b/rpkimancer/cert/asn1.py
@@ -15,14 +15,14 @@ from __future__ import annotations
 
 import logging
 
-from ..asn1 import Content, append_info_object_set
+from ..asn1 import Interface, append_info_object_set
 from ..asn1.mod import PKIX1Explicit_2009
 from ..asn1.types import ASN1Class
 
 log = logging.getLogger(__name__)
 
 
-class Certificate(Content):
+class Certificate(Interface):
     """X.509 ASN.1 Certificate type - RFC5912."""
 
     content_syntax = PKIX1Explicit_2009.Certificate
@@ -46,7 +46,7 @@ class Certificate(Content):
         append_info_object_set(extn_set, ext_type)
 
 
-class SubjectPublicKeyInfo(Content):
+class SubjectPublicKeyInfo(Interface):
     """X.509 ASN.1 SubjectPublicKeyInfo type - RFC5912."""
 
     content_syntax = PKIX1Explicit_2009.SubjectPublicKeyInfo

--- a/rpkimancer/cert/ee.py
+++ b/rpkimancer/cert/ee.py
@@ -22,16 +22,18 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from . import base, ca, oid
 
 if typing.TYPE_CHECKING:
-    from ..sigobj import SignedObject
+    from ..sigobj.base import EncapsulatedContentType, SignedObject
 
 log = logging.getLogger(__name__)
 
+ECT = typing.TypeVar("ECT", bound="EncapsulatedContentType")
 
-class EECertificate(base.BaseResourceCertificate):
+
+class EECertificate(base.BaseResourceCertificate, typing.Generic[ECT]):
     """RPKI EE Certificate - RFC6487."""
 
     def __init__(self, *,
-                 signed_object: SignedObject,
+                 signed_object: SignedObject[ECT],
                  **kwargs: typing.Any) -> None:
         """Initialise the EE Certificate."""
         self._signed_object = signed_object
@@ -39,7 +41,7 @@ class EECertificate(base.BaseResourceCertificate):
         super().__init__(common_name=common_name, **kwargs)
 
     @property
-    def signed_object(self) -> SignedObject:
+    def signed_object(self) -> SignedObject[ECT]:
         """Get the SignedObject that this certificate signs."""
         return self._signed_object
 

--- a/rpkimancer/cli/perceive.py
+++ b/rpkimancer/cli/perceive.py
@@ -23,11 +23,11 @@ import typing
 from . import Args, BaseCommand, Return
 
 if typing.TYPE_CHECKING:
-    from rpkimancer.asn1 import Content
+    from rpkimancer.asn1 import Interface
 
 log = logging.getLogger(__name__)
 
-WriteGenerator = typing.Generator[typing.Callable[["Content", str], None],
+WriteGenerator = typing.Generator[typing.Callable[["Interface", str], None],
                                   None,
                                   None]
 
@@ -110,7 +110,7 @@ class Perceive(BaseCommand):
     @contextlib.contextmanager
     def _output(path: typing.Optional[str] = None) -> WriteGenerator:
 
-        def _write(obj: Content,
+        def _write(obj: Interface,
                    info_property: typing.Optional[str],
                    fmt_method: str,
                    f: typing.TextIO) -> None:

--- a/rpkimancer/cms.py
+++ b/rpkimancer/cms.py
@@ -60,16 +60,20 @@ class ContentInfo(Interface, typing.Generic[CT]):
 
 
 class ContentTypeIdDescriptor:
+    """Data descriptor for 'content_type' class property."""
 
     def __get__(self, instance: typing.Optional[CT],
                 owner: typing.Type[CT]) -> OID:
+        """Get CONTENT-TYPE.&id."""
         return owner.asn1_definition.get_val()["id"]
 
 
 class ContentTypeSyntaxDescriptor:
+    """Data descriptor for 'content_syntax' class property."""
 
     def __get__(self, instance: typing.Optional[CT],
                 owner: typing.Type[CT]) -> ASN1Obj:
+        """Get CONTENT-TYPE.&Type."""
         return owner.asn1_definition.get_val()["Type"].get_typeref()
 
 

--- a/rpkimancer/cms.py
+++ b/rpkimancer/cms.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import logging
 import typing
 
-from .asn1 import Content, append_info_object_set
+from .asn1 import Interface, append_info_object_set
 from .asn1.mod import CryptographicMessageSyntax_2009
 from .asn1.types import ASN1Class, OID
 
@@ -26,13 +26,13 @@ ContentDataSubclass = typing.TypeVar("ContentDataSubclass",
                                      bound="ContentData")
 
 
-class ContentData(Content):
+class ContentData(Interface):
     """Generic base class for ASN.1 types idenitied by an OID."""
 
     content_type: OID
 
 
-class ContentInfo(Content):
+class ContentInfo(Interface):
     """CMS ASN.1 ContentInfo type - RFC5911."""
 
     content_syntax = CryptographicMessageSyntax_2009.ContentInfo
@@ -70,7 +70,7 @@ class SignedData(ContentData):
     content_syntax = CryptographicMessageSyntax_2009.SignedData
 
 
-class SignedAttributes(Content):
+class SignedAttributes(Interface):
     """CMS ASN.1 SignedAttributes type - RFC5911."""
 
     content_syntax = CryptographicMessageSyntax_2009.SignedAttributes
@@ -93,7 +93,7 @@ class SignedAttributes(Content):
         super().__init__(data)
 
 
-class EncapsulatedContentInfo(Content):
+class EncapsulatedContentInfo(Interface):
     """CMS ASN.1 EncapsulatedContentInfo type - RFC5911."""
 
     content_syntax = CryptographicMessageSyntax_2009.EncapsulatedContentInfo

--- a/rpkimancer/cms.py
+++ b/rpkimancer/cms.py
@@ -16,31 +16,26 @@ from __future__ import annotations
 import logging
 import typing
 
+from .algorithms import DigestAlgorithm
 from .asn1 import Interface, append_info_object_set
 from .asn1.mod import CryptographicMessageSyntax_2009
-from .asn1.types import ASN1Class, OID
+from .asn1.types import ASN1Class, ASN1Obj, OID
 
 log = logging.getLogger(__name__)
 
-ContentDataSubclass = typing.TypeVar("ContentDataSubclass",
-                                     bound="ContentData")
+CT = typing.TypeVar("CT", bound="ContentType")
+ECT = typing.TypeVar("ECT", bound="ContentType")
 
 
-class ContentData(Interface):
-    """Generic base class for ASN.1 types idenitied by an OID."""
-
-    content_type: OID
-
-
-class ContentInfo(Interface):
+class ContentInfo(Interface, typing.Generic[CT]):
     """CMS ASN.1 ContentInfo type - RFC5911."""
 
     content_syntax = CryptographicMessageSyntax_2009.ContentInfo
 
-    def __init__(self, content: ContentData) -> None:
+    def __init__(self, content: CT) -> None:
         """Initialise the instance from contained ContentData."""
         log.info(f"preparing data for {self}")
-        content_type_oid = content.content_type.get_val()
+        content_type_oid = content.content_type
         content_type_name = content.content_syntax.fullname()
         content_data = content.content_data
         data = {"contentType": content_type_oid,
@@ -49,25 +44,48 @@ class ContentInfo(Interface):
 
     @classmethod
     def register_econtent_type(cls,
-                               content_type: typing.Type[ContentDataSubclass],
-                               econtent_type: ASN1Class) -> None:
+                               content_type: typing.Type[CT],
+                               econtent_type: typing.Type[ECT]) -> None:
         """Add CONTENT-TYPE instance to eContentType constraint set."""
         content = cls.content_syntax.get_internals()["cont"]["content"]
         content_const_set = content.get_const()["tab"].get_val()
-        content_type_oid = content_type.content_type.get_val()
+        content_type_oid = content_type.content_type
         content_data_inst = list(filter(lambda item: item["id"] == content_type_oid,  # noqa: E501
                                         content_const_set.getv()))[0]["Type"]
         encap_content_info = content_data_inst.get_internals()["cont"]["encapContentInfo"]  # noqa: E501
         econtent_open_type = encap_content_info.get_internals()["cont"]["eContentType"]  # noqa: E501
         econtent_const_set = econtent_open_type.get_const()["tab"]
-        append_info_object_set(econtent_const_set, econtent_type)
+        append_info_object_set(econtent_const_set,
+                               econtent_type.asn1_definition)
 
 
-class SignedData(ContentData):
-    """CMS ASN.1 SignedData type - RFC5911."""
+class ContentTypeIdDescriptor:
 
-    content_type = CryptographicMessageSyntax_2009.id_signedData
-    content_syntax = CryptographicMessageSyntax_2009.SignedData
+    def __get__(self, instance: typing.Optional[CT],
+                owner: typing.Type[CT]) -> OID:
+        return owner.asn1_definition.get_val()["id"]
+
+
+class ContentTypeSyntaxDescriptor:
+
+    def __get__(self, instance: typing.Optional[CT],
+                owner: typing.Type[CT]) -> ASN1Obj:
+        return owner.asn1_definition.get_val()["Type"].get_typeref()
+
+
+class ContentType(Interface):
+    """CMS ASN.1 CONTENT-TYPE instance - RFC5911."""
+
+    asn1_definition: ASN1Class
+
+    content_type = ContentTypeIdDescriptor()
+    content_syntax = ContentTypeSyntaxDescriptor()
+
+
+class SignedData(ContentType):
+    """CMS ASN.1 ct-SignedData CONTENT-TYPE instance - RFC5911."""
+
+    asn1_definition = CryptographicMessageSyntax_2009.ct_SignedData
 
 
 class SignedAttributes(Interface):
@@ -83,7 +101,7 @@ class SignedAttributes(Interface):
         data = [
             {
                 "attrType": ct_attr_oid,
-                "attrValues": [('ContentType', content_type.get_val())],
+                "attrValues": [('ContentType', content_type)],
             },
             {
                 "attrType": md_attr_oid,
@@ -93,19 +111,28 @@ class SignedAttributes(Interface):
         super().__init__(data)
 
 
-class EncapsulatedContentInfo(Interface):
+class EncapsulatedContentInfo(Interface, typing.Generic[CT]):
     """CMS ASN.1 EncapsulatedContentInfo type - RFC5911."""
 
     content_syntax = CryptographicMessageSyntax_2009.EncapsulatedContentInfo
 
+    digest_algorithm: DigestAlgorithm
+
+    def __init__(self, econtent: CT) -> None:
+        """Initialise the instance from contained ContentData."""
+        log.info(f"preparing data for {self}")
+        data = {"eContentType": econtent.content_type,
+                "eContent": econtent.to_der()}
+        super().__init__(data)
+
     @classmethod
     def from_content_info(cls,
-                          content_info: ContentInfo) -> EncapsulatedContentInfo:  # noqa: E501
+                          content_info: ContentInfo[SignedData]) -> EncapsulatedContentInfo[CT]:  # noqa: E501
         """De-encapsulate from ContentInfo instance."""
         val_path = ["content", "SignedData", "encapContentInfo"]
         with content_info.constructed() as instance:
             data = instance.get_val_at(val_path)
-        return cls(data)
+        return cls.from_data(data)
 
     @property
     def econtent_val(self) -> typing.Any:

--- a/rpkimancer/resources.py
+++ b/rpkimancer/resources.py
@@ -61,8 +61,10 @@ def bitstring_to_net(bits: IPNetworkBits, version: int) -> IPNetwork:
     return typing.cast(IPNetwork, net)
 
 
-class SeqOfIPAddressFamily(Interface):
-    """Base class for ASN.1 SEQUENCE OF IPAddressFamily types."""
+class IPAddrBlocks(Interface):
+    """ASN.1 IPAddrBlocks type - RFC3779."""
+
+    content_syntax = IPAddrAndASCertExtn.IPAddrBlocks
 
     def __init__(self, ip_resources: IpResourcesInfo) -> None:
         """Initialise instance from python data."""
@@ -97,12 +99,6 @@ class SeqOfIPAddressFamily(Interface):
         data = [{"addressFamily": afi, "ipAddressChoice": _combine(entries)}
                 for afi, entries in by_afi.items() if entries]
         super().__init__(data)
-
-
-class IPAddrBlocks(SeqOfIPAddressFamily):
-    """ASN.1 IPAddrBlocks type - RFC3779."""
-
-    content_syntax = IPAddrAndASCertExtn.IPAddrBlocks
 
 
 class ASIdOrRange(Interface):

--- a/rpkimancer/resources.py
+++ b/rpkimancer/resources.py
@@ -17,7 +17,7 @@ import ipaddress
 import logging
 import typing
 
-from .asn1 import Content
+from .asn1 import Interface
 from .asn1.mod import IPAddrAndASCertExtn
 
 log = logging.getLogger(__name__)
@@ -61,7 +61,7 @@ def bitstring_to_net(bits: IPNetworkBits, version: int) -> IPNetwork:
     return typing.cast(IPNetwork, net)
 
 
-class SeqOfIPAddressFamily(Content):
+class SeqOfIPAddressFamily(Interface):
     """Base class for ASN.1 SEQUENCE OF IPAddressFamily types."""
 
     def __init__(self, ip_resources: IpResourcesInfo) -> None:
@@ -105,7 +105,7 @@ class IPAddrBlocks(SeqOfIPAddressFamily):
     content_syntax = IPAddrAndASCertExtn.IPAddrBlocks
 
 
-class ASIdOrRange(Content):
+class ASIdOrRange(Interface):
     """ASN.1 ASIdOrRange type - RFC3779."""
 
     content_syntax = IPAddrAndASCertExtn.ASIdOrRange
@@ -122,7 +122,7 @@ class ASIdOrRange(Content):
         super().__init__(data)
 
 
-class ASIdentifiers(Content):
+class ASIdentifiers(Interface):
     """ASN.1 ASIdentifiers type - RFC3779."""
 
     content_syntax = IPAddrAndASCertExtn.ASIdentifiers

--- a/rpkimancer/sigobj/__init__.py
+++ b/rpkimancer/sigobj/__init__.py
@@ -17,33 +17,33 @@ import importlib.metadata
 import logging
 import typing
 
-from . import base, gbr, mft, roa
+from . import gbr, mft, roa
+from .base import SignedObject
 
 log = logging.getLogger(__name__)
-
-SignedObject = base.SignedObject
-
-SignedObjectSubclass = typing.TypeVar("SignedObjectSubclass",
-                                      bound=SignedObject)
 
 RpkiGhostbusters = gbr.RpkiGhostbusters
 RpkiManifest = mft.RpkiManifest
 RouteOriginAttestation = roa.RouteOriginAttestation
 
+S = typing.Type[SignedObject[typing.Any]]
 
-def from_ext(ext: str) -> typing.Type[SignedObject]:
+
+def from_ext(ext: str) -> S:
     """Get a SignedObject by file extension."""
-    object_types = [RpkiGhostbusters, RpkiManifest, RouteOriginAttestation]
+    object_types: typing.List[S] = [RpkiGhostbusters,
+                                    RpkiManifest,
+                                    RouteOriginAttestation]
     entry_point_name = "rpkimancer.sigobj"
     entry_points = importlib.metadata.entry_points()
     for entry_point in entry_points.get(entry_point_name, []):
         log.info(f"trying to load signed object {entry_point.value}")
         cls = entry_point.load()
         if issubclass(cls, SignedObject):
-            object_types.append(cls)
+            object_types.append(typing.cast(S, cls))
         else:
             log.warning(f"signed objects must inherit from {SignedObject}")
-    lookup_map = {cls.econtent_cls.file_ext: cls
+    lookup_map = {cls.econtent_type.file_ext: cls
                   for cls in object_types}
     try:
         return lookup_map[ext]

--- a/rpkimancer/sigobj/base.py
+++ b/rpkimancer/sigobj/base.py
@@ -18,7 +18,7 @@ import os
 import typing
 
 from ..algorithms import DIGEST_ALGORITHMS, SHA256
-from ..asn1 import Content
+from ..asn1 import Interface
 from ..asn1.mod import PKIXAlgs_2009
 from ..asn1.types import ASN1Class, OID
 from ..cert import EECertificate
@@ -36,7 +36,7 @@ log = logging.getLogger(__name__)
 CMS_VERSION: typing.Final = 3
 
 
-class EncapsulatedContent(Content):
+class EncapsulatedContent(Interface):
     """Base class for encapContentInfo in RPKI Signed Objects - RFC6488."""
 
     digest_algorithm = DIGEST_ALGORITHMS[SHA256]

--- a/rpkimancer/sigobj/gbr.py
+++ b/rpkimancer/sigobj/gbr.py
@@ -71,6 +71,5 @@ class RpkiGhostbustersContentType(EncapsulatedContentType):
         return json.dumps(data, indent=2)
 
 
-class RpkiGhostbusters(SignedObject[RpkiGhostbustersContentType],
-                       econtent_type=RpkiGhostbustersContentType):
+class RpkiGhostbusters(SignedObject[RpkiGhostbustersContentType]):
     """CMS ASN.1 ContentInfo for RPKI Ghostbusters Records."""

--- a/rpkimancer/sigobj/gbr.py
+++ b/rpkimancer/sigobj/gbr.py
@@ -17,18 +17,17 @@ import json
 import logging
 import typing
 
-from .base import EncapsulatedContent, SignedObject
+from .base import EncapsulatedContentType, SignedObject
 from ..asn1.mod import RPKIGhostbusters
 from ..resources import INHERIT_AS, INHERIT_IPV4, INHERIT_IPV6
 
 log = logging.getLogger(__name__)
 
 
-class RpkiGhostbustersEContent(EncapsulatedContent):
+class RpkiGhostbustersContentType(EncapsulatedContentType):
     """encapContentInfo for RPKI Ghostbusters Record - RFC6493."""
 
-    content_type = RPKIGhostbusters.id_ct_rpkiGhostbusters
-    content_syntax = RPKIGhostbusters.GhostbustersRecord
+    asn1_definition = RPKIGhostbusters.ct_rpkiGhostbusters
     file_ext = "gbr"
     as_resources = INHERIT_AS
     ip_resources = [INHERIT_IPV4, INHERIT_IPV6]
@@ -72,8 +71,6 @@ class RpkiGhostbustersEContent(EncapsulatedContent):
         return json.dumps(data, indent=2)
 
 
-class RpkiGhostbusters(SignedObject,
-                       econtent_type=RPKIGhostbusters.ct_rpkiGhostbusters):
+class RpkiGhostbusters(SignedObject[RpkiGhostbustersContentType],
+                       econtent_type=RpkiGhostbustersContentType):
     """CMS ASN.1 ContentInfo for RPKI Ghostbusters Records."""
-
-    econtent_cls = RpkiGhostbustersEContent

--- a/rpkimancer/sigobj/mft.py
+++ b/rpkimancer/sigobj/mft.py
@@ -17,7 +17,7 @@ import datetime
 import logging
 import typing
 
-from .base import EncapsulatedContent, SignedObject
+from .base import EncapsulatedContentType, SignedObject
 from ..algorithms import SHA256
 from ..asn1.mod import RPKIManifest
 from ..resources import INHERIT_AS, INHERIT_IPV4, INHERIT_IPV6
@@ -26,25 +26,23 @@ log = logging.getLogger(__name__)
 
 GeneralizedTimeInfo = typing.Tuple[typing.Optional[str], ...]
 HashInfo = typing.Tuple[int, int]
+FileListInfo = typing.List[typing.Tuple[str, bytes]]
 
 
-class RpkiManifestEContent(EncapsulatedContent):
+class RpkiManifestContentType(EncapsulatedContentType):
     """encapContentInfo for RPKI Manifests - RFC6486."""
 
-    content_type = RPKIManifest.id_ct_rpkiManifest
-    content_syntax = RPKIManifest.Manifest
+    asn1_definition = RPKIManifest.ct_rpkiManifest
     file_ext = "mft"
     as_resources = INHERIT_AS
     ip_resources: typing.Final = (INHERIT_IPV4, INHERIT_IPV6)
-
-    _file_list_type = typing.List[typing.Tuple[str, bytes]]
 
     def __init__(self, *,
                  version: int = 0,
                  manifest_number: int = 0,
                  this_update: datetime.datetime,
                  next_update: datetime.datetime,
-                 file_list: _file_list_type) -> None:
+                 file_list: FileListInfo) -> None:
         """Initialise the encapContentInfo."""
         log.info(f"preparing data for {self}")
         data = {"version": version,
@@ -71,8 +69,6 @@ class RpkiManifestEContent(EncapsulatedContent):
         return (hash_bits, hash_len)
 
 
-class RpkiManifest(SignedObject,
-                   econtent_type=RPKIManifest.ct_rpkiManifest):
+class RpkiManifest(SignedObject[RpkiManifestContentType],
+                   econtent_type=RpkiManifestContentType):
     """CMS ASN.1 ContentInfo for RPKI Manifests."""
-
-    econtent_cls = RpkiManifestEContent

--- a/rpkimancer/sigobj/mft.py
+++ b/rpkimancer/sigobj/mft.py
@@ -69,6 +69,5 @@ class RpkiManifestContentType(EncapsulatedContentType):
         return (hash_bits, hash_len)
 
 
-class RpkiManifest(SignedObject[RpkiManifestContentType],
-                   econtent_type=RpkiManifestContentType):
+class RpkiManifest(SignedObject[RpkiManifestContentType]):
     """CMS ASN.1 ContentInfo for RPKI Manifests."""

--- a/rpkimancer/sigobj/roa.py
+++ b/rpkimancer/sigobj/roa.py
@@ -18,7 +18,7 @@ import json
 import logging
 import typing
 
-from .base import EncapsulatedContent, SignedObject
+from .base import EncapsulatedContentType, SignedObject
 from ..asn1.mod import RPKI_ROA
 from ..resources import (AFI, IPNetwork, IPNetworkBits, IpResourcesInfo,
                          bitstring_to_net, net_to_bitstring)
@@ -28,11 +28,10 @@ log = logging.getLogger(__name__)
 RoaNetworkInfo = typing.Tuple[IPNetwork, typing.Optional[int]]
 
 
-class RouteOriginAttestationEContent(EncapsulatedContent):
+class RouteOriginAttestationContentType(EncapsulatedContentType):
     """encapContentInfo for RPKI ROAs - RFC6482."""
 
-    content_type = RPKI_ROA.id_ct_routeOriginAuthz
-    content_syntax = RPKI_ROA.RouteOriginAttestation
+    asn1_definition = RPKI_ROA.ct_routeOriginAuthz
     file_ext = "roa"
     as_resources = None
 
@@ -84,8 +83,6 @@ class RouteOriginAttestationEContent(EncapsulatedContent):
         return json.dumps(data, indent=2)
 
 
-class RouteOriginAttestation(SignedObject,
-                             econtent_type=RPKI_ROA.ct_routeOriginAuthz):
+class RouteOriginAttestation(SignedObject[RouteOriginAttestationContentType],
+                             econtent_type=RouteOriginAttestationContentType):
     """CMS ASN.1 ContentInfo for RPKI ROAs."""
-
-    econtent_cls = RouteOriginAttestationEContent

--- a/rpkimancer/sigobj/roa.py
+++ b/rpkimancer/sigobj/roa.py
@@ -83,6 +83,5 @@ class RouteOriginAttestationContentType(EncapsulatedContentType):
         return json.dumps(data, indent=2)
 
 
-class RouteOriginAttestation(SignedObject[RouteOriginAttestationContentType],
-                             econtent_type=RouteOriginAttestationContentType):
+class RouteOriginAttestation(SignedObject[RouteOriginAttestationContentType]):
     """CMS ASN.1 ContentInfo for RPKI ROAs."""

--- a/rpkimancer/utils.py
+++ b/rpkimancer/utils.py
@@ -9,7 +9,7 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-"""Compile and re-export the provided ASN.1 modules."""
+"""Utilities and helper classes and functions."""
 from __future__ import annotations
 
 import contextlib

--- a/tests/rpkimancer_foo/sigobj.py
+++ b/tests/rpkimancer_foo/sigobj.py
@@ -17,16 +17,15 @@ import logging
 
 from rpkimancer.asn1.mod import RpkiFoo
 from rpkimancer.resources import INHERIT_AS, INHERIT_IPV4, INHERIT_IPV6
-from rpkimancer.sigobj.base import EncapsulatedContent, SignedObject
+from rpkimancer.sigobj.base import EncapsulatedContentType, SignedObject
 
 log = logging.getLogger(__name__)
 
 
-class FooObjectEContent(EncapsulatedContent):
+class FooObjectContentType(EncapsulatedContentType):
     """encapContentInfo for RPKI Foo Objects."""
 
-    content_type = RpkiFoo.id_ct_rpkiFooObject
-    content_syntax = RpkiFoo.RpkiFooObject
+    asn1_definition = RpkiFoo.ct_rpkiFooObject
     file_ext = "foo"
     as_resources = INHERIT_AS
     ip_resources = [INHERIT_IPV4, INHERIT_IPV6]
@@ -37,7 +36,6 @@ class FooObjectEContent(EncapsulatedContent):
         super().__init__(data)
 
 
-class FooObject(SignedObject):
+class FooObject(SignedObject[FooObjectContentType],
+                econtent_type=FooObjectContentType):
     """CMS ASN.1 ContentInfo for RPKI Foo Objects."""
-
-    econtent_cls = FooObjectEContent

--- a/tests/rpkimancer_foo/sigobj.py
+++ b/tests/rpkimancer_foo/sigobj.py
@@ -36,6 +36,5 @@ class FooObjectContentType(EncapsulatedContentType):
         super().__init__(data)
 
 
-class FooObject(SignedObject[FooObjectContentType],
-                econtent_type=FooObjectContentType):
+class FooObject(SignedObject[FooObjectContentType]):
     """CMS ASN.1 ContentInfo for RPKI Foo Objects."""


### PR DESCRIPTION
- rename `asn1.Content` to `asn1.Interface`
- make `CONTENT-TYPE` instances first-class citizens
- look-up `CONTENT-TYPE` instance via generic type introspection during
  `sigobj.base.SignedObject` subclass initialisation
